### PR TITLE
Basic Bug Fixes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,7 +54,6 @@ int main(int argc, char* argv[])
 	verbose 	= ADS1X15_MAIN_DEFAULT_VERBOSITY;
 	debug 		= ADS1X15_MAIN_DEFAULT_DEBUG;
 
-
 	//// parse the option arguments
 	while ((ch = getopt(argc, argv, "xvqdh")) != -1) {
 		switch (ch) {
@@ -111,7 +110,9 @@ int main(int argc, char* argv[])
 			printf ("ERROR: invalid max input voltage!\n");
 			return EXIT_FAILURE;
 		}
-	}
+	} else {
+            gain = 0;
+        }
 
 
 	//// actual program

--- a/src/onion-ads1x15-driver.cpp
+++ b/src/onion-ads1x15-driver.cpp
@@ -242,7 +242,8 @@ int ads1X15::ReadAdc (int channel, int &value)
 	configReg.f.status_start 		= 1;
 
 
-	// write to the config register
+	// write to the config register after required swap of byte order
+        configReg.val = ((configReg.val & 0xff) << 8) | ((configReg.val & 0xff00) >> 8);
 	status = _WriteReg	( 	ADS1X15_REG_ADDR_CONFIG,
 							configReg.val,
 							2


### PR DESCRIPTION
1. Correct order of command bytes sent over I2C
2. Ensure default gain correctly set when no gain specified on the
   command line
